### PR TITLE
refactor: 프로필 사진 수정

### DIFF
--- a/src/main/java/com/spacestar/back/profile/controller/ProfileController.java
+++ b/src/main/java/com/spacestar/back/profile/controller/ProfileController.java
@@ -178,9 +178,9 @@ public class ProfileController {
     @Operation(summary = "프로필 사진 삭제")
     @DeleteMapping("/image")
     public ResponseEntity<Void> deleteProfileImage(@RequestHeader("UUID") String uuid,
-                                                   @RequestBody ProfileImageReqVo profileImageReqVo) {
+                                                   @RequestBody ProfileImageDeleteReqVo profileImageDeleteReqVo) {
 
-        profileService.deleteProfileImage(uuid, mapper.map(profileImageReqVo, ProfileImageReqDto.class));
+        profileService.deleteProfileImage(uuid, mapper.map(profileImageDeleteReqVo, ProfileImageDeleteReqDto.class));
         return new ResponseEntity<>(ResponseSuccess.PROFILE_IMAGE_DELETE_SUCCESS);
     }
 

--- a/src/main/java/com/spacestar/back/profile/dto/req/ProfileImageDeleteReqDto.java
+++ b/src/main/java/com/spacestar/back/profile/dto/req/ProfileImageDeleteReqDto.java
@@ -1,0 +1,15 @@
+package com.spacestar.back.profile.dto.req;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ProfileImageDeleteReqDto {
+
+    private String profileImageUrl;
+}

--- a/src/main/java/com/spacestar/back/profile/dto/req/ProfileImageReqDto.java
+++ b/src/main/java/com/spacestar/back/profile/dto/req/ProfileImageReqDto.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 public class ProfileImageReqDto {
 
     private String profileImageUrl;
+    private boolean main;
 
 
     public static ProfileImage addNewImage(String uuid, boolean b, String profileImageUrl) {

--- a/src/main/java/com/spacestar/back/profile/service/ProfileService.java
+++ b/src/main/java/com/spacestar/back/profile/service/ProfileService.java
@@ -29,7 +29,7 @@ public interface ProfileService {
 
     void updateSwipeRecommend(String uuid, ProfileSwipeResDto profileSwipeResDto);
 
-    void deleteProfileImage(String uuid, ProfileImageReqDto profileImageReqDto);
+    void deleteProfileImage(String uuid, ProfileImageDeleteReqDto profileImageDeleteReqDto);
 
     void updateLikedGameInfo(String uuid, LikedGameInfoReqDto likedGameInfoReqDto);
 

--- a/src/main/java/com/spacestar/back/profile/service/ProfileServiceImp.java
+++ b/src/main/java/com/spacestar/back/profile/service/ProfileServiceImp.java
@@ -160,7 +160,7 @@ public class ProfileServiceImp implements ProfileService {
 
         //역순
         List<ProfileImageListResDto> dtoList = new ArrayList<>(IntStream.range(0, profileImages.size())
-                .mapToObj(index -> ProfileImageListResDto.convertToDto(profileImages.size()-index-1, profileImages.get(index)))
+                .mapToObj(index -> ProfileImageListResDto.convertToDto(profileImages.size() - index - 1, profileImages.get(index)))
                 .toList());
         Collections.reverse(dtoList);
         return dtoList;
@@ -171,8 +171,14 @@ public class ProfileServiceImp implements ProfileService {
     @Override
     public ProfileMainImageResDto findMainProfileImage(String uuid) {
 
-        return mapper.map(
-                profileImageRepository.findByUuidAndMain(uuid, true), ProfileMainImageResDto.class);
+        ProfileImage profileImage = profileImageRepository.findByUuidAndMain(uuid, true);
+        ProfileMainImageResDto profileMainImageResDto = ProfileMainImageResDto.builder()
+                .profileImageUrl(null)
+                .build();
+        if (profileImage != null) {
+            profileMainImageResDto = mapper.map(profileImage, ProfileMainImageResDto.class);
+        }
+        return profileMainImageResDto;
     }
 
     //프로필 사진 추가
@@ -180,36 +186,63 @@ public class ProfileServiceImp implements ProfileService {
     @Override
     public void addProfileImage(String uuid, ProfileImageReqDto profileImageReqDto) {
 
-        ProfileImage profileImage = profileImageRepository.findByUuidAndMain(uuid, true);
+        // 메인 사진 유무 확인
+        ProfileImage profileMainImage = profileImageRepository.findByUuidAndMain(uuid, true);
 
-        //메인 사진 비활성화
-        if (profileImage != null) {
-            profileImageRepository.save(ProfileImageReqDto.updateImage(uuid, profileImage.getId(), false, profileImage.getProfileImageUrl()));
+        // 메인 사진이 없을 경우 -> 추가한 사진이 메인
+        if (profileMainImage == null) {
+            profileImageRepository.save(ProfileImageReqDto.addNewImage(uuid, true, profileImageReqDto.getProfileImageUrl()));
+        } else {
+            ProfileImage profileImage = profileImageRepository.findByUuidAndProfileImageUrl(uuid, profileImageReqDto.getProfileImageUrl());
+
+
+            // 추가된 사진이 메인인 경우
+            if (profileImageReqDto.isMain()) {
+                // 메인 사진이 있을 경우
+                if (profileMainImage != null) {
+                    profileImageRepository.save(ProfileImageReqDto.updateImage(uuid, profileMainImage.getId(), false, profileMainImage.getProfileImageUrl()));
+                }
+
+                // 메인으로 할 사진이 원래 있는 사진인 경우
+                if (profileImage != null) {
+                    profileImageRepository.save(ProfileImageReqDto.updateImage(uuid, profileImage.getId(), true, profileImage.getProfileImageUrl()));
+                } else {
+                    // 새로운 사진이 메인인 경우
+                    profileImageRepository.save(ProfileImageReqDto.addNewImage(uuid, true, profileImageReqDto.getProfileImageUrl()));
+                }
+            }
+            //메인 아님
+            else {
+                profileImageRepository.save(ProfileImageReqDto.addNewImage(uuid, false, profileImageReqDto.getProfileImageUrl()));
+            }
         }
-        //가장 최근 사진이 메인 프로필
-        profileImageRepository.save(ProfileImageReqDto.addNewImage(uuid, true, profileImageReqDto.getProfileImageUrl()));
 
     }
 
     //프로필 사진 삭제
     @Transactional
     @Override
-    public void deleteProfileImage(String uuid, ProfileImageReqDto profileImageReqDto) {
+    public void deleteProfileImage(String uuid, ProfileImageDeleteReqDto profileImageDeleteReqDto) {
 
         ProfileImage profileImage = profileImageRepository.findByUuidAndMain(uuid, true);
 
         //메인 사진 삭제
-        if (profileImage.getProfileImageUrl().equals(profileImageReqDto.getProfileImageUrl())) {
+        if (profileImage.getProfileImageUrl().equals(profileImageDeleteReqDto.getProfileImageUrl())) {
             log.info("메인 사진 삭제");
             profileImageRepository.delete(profileImage);
             //이전 이미지가 메인이 됨
             ProfileImage newMain = profileImageRepository.findLastByUuid(uuid);
-            profileImageRepository.save(ProfileImageReqDto.updateImage(uuid, newMain.getId(), true, newMain.getProfileImageUrl()));
+
+            if (newMain != null) {
+                profileImageRepository.save(ProfileImageReqDto.updateImage(uuid, newMain.getId(), true, newMain.getProfileImageUrl()));
+            }
+
+
         }
         //일반 사진 삭제
         else {
             log.info("일반 사진 삭제");
-            ProfileImage beDelete = profileImageRepository.findByUuidAndProfileImageUrl(uuid, profileImageReqDto.getProfileImageUrl());
+            ProfileImage beDelete = profileImageRepository.findByUuidAndProfileImageUrl(uuid, profileImageDeleteReqDto.getProfileImageUrl());
             profileImageRepository.delete(beDelete);
         }
 

--- a/src/main/java/com/spacestar/back/profile/vo/req/ProfileImageDeleteReqVo.java
+++ b/src/main/java/com/spacestar/back/profile/vo/req/ProfileImageDeleteReqVo.java
@@ -3,8 +3,7 @@ package com.spacestar.back.profile.vo.req;
 import lombok.Getter;
 
 @Getter
-public class ProfileImageReqVo {
+public class ProfileImageDeleteReqVo {
 
     private String profileImageUrl;
-    private boolean main;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #40 
## 📝작업 내용

> 사진 모두 삭제 시 빈리스트 리턴
> 사진이 하나도 없을 때, 사진 추가 시 그 사진이 메인 프로필 사진
> 원래 있던 사진을 메인 프로필 사진으로 등록
> 메인 프로필 사진 삭제 시 가장 최근의 사진이 메인 프로필 사진
-> 원래 있던 사진은 메인 프로필 사진으로 등록하는 경우를 제외하고 다시 추가 시 오류 발생